### PR TITLE
bugifxes for vanilla resources and UCP bugfix troops files (#723)

### DIFF
--- a/UnofficialCrusaderPatch/Startup/Resources/Goods/vanilla.json
+++ b/UnofficialCrusaderPatch/Startup/Resources/Goods/vanilla.json
@@ -70,7 +70,7 @@
 		"iron": 25,
 		"pitch": 48,
 		"wheat": 25,
-		"bread": 150,
+		"bread": 200,
 		"cheese": 0,
 		"meat": 0,
 		"fruit": 0,

--- a/UnofficialCrusaderPatch/Startup/Resources/Troops/UCP-StartingTroops-Patch.json
+++ b/UnofficialCrusaderPatch/Startup/Resources/Troops/UCP-StartingTroops-Patch.json
@@ -150,7 +150,7 @@
     },
     "crusader": {
       "Units": [ "ArabSwordsman", "ArabArcher", "FireThrower" ],
-      "Counts": [ 8, 8, 50 ]
+      "Counts": [ 8, 50, 8 ]
     },
     "deathmatch": {
       "Units": [ "ArabSwordsman", "ArabArcher", "FireThrower" ],


### PR DESCRIPTION
* bugfix for vanilla bread 150->200
bugfix for UCP-StartingTroops-Patch -> caliph swapped numbers of ArabArcher and Firethrowers that were mixed up